### PR TITLE
Fixed error and prop spam

### DIFF
--- a/lua/weapons/gmod_tool/stools/adv_duplicator.lua
+++ b/lua/weapons/gmod_tool/stools/adv_duplicator.lua
@@ -318,7 +318,7 @@ function TOOL:MakeGhostFromTable( EntTable, pParent, HoldAngle, HoldPos )
 	GhostEntity:Spawn()
 
 	for _, modifier in ipairs(GhostModifiers) do
-		if EntTable.EntityMods[modifier] then
+		if EntTable.EntityMods and EntTable.EntityMods[modifier] then
 			duplicator.EntityModifiers[modifier](self:GetOwner(), GhostEntity, EntTable.EntityMods[modifier])
 		end
 	end


### PR DESCRIPTION
Loading ghost stuck on 16% and spamming props each tick.

```
[ERROR] addons/advduplicator/lua/weapons/gmod_tool/stools/adv_duplicator.lua:321: attempt to index field 'EntityMods' (a nil value)
  1. MakeGhostFromTable - addons/advduplicator/lua/weapons/gmod_tool/stools/adv_duplicator.lua:321
   2. AddToGhost - addons/advduplicator/lua/weapons/gmod_tool/stools/adv_duplicator.lua:539
    3. Think - addons/advduplicator/lua/weapons/gmod_tool/stools/adv_duplicator.lua:285
     4. unknown - gamemodes/sandbox/entities/weapons/gmod_tool/shared.lua:194
```

![2013-08-13_00002](https://f.cloud.github.com/assets/332791/953353/a0c895fc-03f3-11e3-895f-5a02219a803d.jpg)
